### PR TITLE
chore: removed py/github_wipeout_deployments

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "py/selenium_cafe_migrations"]
 	path = py/selenium_cafe_migrations
 	url = git@gist.github.com:db56c2d9038535d8c228a5874b058355.git
-[submodule "py/github_wipeout_deployments"]
-	path = py/github_wipeout_deployments
-	url = git@gist.github.com:32ce58412d108dcdba129f4032e795b0.git
 [submodule "rb/hello_sonic_pi"]
 	path = rb/hello_sonic_pi
 	url = git@gist.github.com:2b043870efb765a7443e3c36da63dd0f.git

--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ So the following operation will be required when we change snippets in Gist for 
 Note that these operations requires to clone this repo recursively, whereas by default `git clone` does not do this.
 ```shell
 % git clone --recursive git@github.com:hwakabh/gists.git
+% git fetch --all --prune --recurse-submodules=yes
 ```


### PR DESCRIPTION
## Issue/PR link
N/A

## What does this PR do?
Describe what changes you make in your branch:
- adding commands for recursive fetching
- removed py/github_wipeout_deployments since it has been already deleted from Gist, by converting as project (hwakabh/envkeeper)

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
N/A